### PR TITLE
Add clue for when element is found but does not contain expected text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,5 +213,13 @@
       <version>5.1.6</version>
       <optional>true</optional>
     </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.6.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/net/codestory/simplelenium/Check.java
+++ b/src/main/java/net/codestory/simplelenium/Check.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2013 all@code-story.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.codestory.simplelenium;
+
+public abstract class Check<T> {
+  private final String description;
+  private final String negatedDescription;
+
+  public Check(String description, String negatedDescription) {
+    this.description = description;
+    this.negatedDescription = negatedDescription;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  protected abstract Result execute(T element);
+
+  public Check<T> negate() {
+    return new Negated(this);
+  }
+
+  protected Result ok() {
+    return new Result(true, description);
+  }
+
+  protected Result ok(String clue) {
+    return new Result(true, clue);
+  }
+
+  protected Result ko(String clue) {
+    return new Result(false, clue);
+  }
+
+  private static class Negated<T> extends Check<T> {
+    private final Check<T> check;
+
+    Negated(Check<T> check) {
+      super(check.negatedDescription, check.description);
+      this.check = check;
+    }
+
+    @Override
+    protected Result execute(T element) {
+      Result checkResult = check.execute(element);
+      return new Result(!checkResult.isOk(), checkResult.message);
+    }
+
+    @Override
+    public Check<T> negate() {
+      return check;
+    }
+  }
+
+  public static class Result {
+    final String message;
+    private final boolean success;
+
+    private Result(boolean success, String message) {
+      this.success = success;
+      this.message = message;
+    }
+
+    public boolean isOk() {
+      return success;
+    }
+  }
+}

--- a/src/main/java/net/codestory/simplelenium/Verification.java
+++ b/src/main/java/net/codestory/simplelenium/Verification.java
@@ -15,6 +15,53 @@
  */
 package net.codestory.simplelenium;
 
-enum Verification {
-  NOT_FOUND, OK, KO
+class Verification {
+  private static final Verification NOT_FOUND = new Verification(null);
+  private static final Verification OK = new Verification(null);
+
+  static Verification ko() {
+    return ko(null);
+  }
+
+  static Verification ko(String clue) {
+    return new Verification(clue);
+  }
+
+  static Verification ok() {
+    return OK;
+  }
+
+  static Verification notFound() {
+    return NOT_FOUND;
+  }
+
+  private final String clue;
+
+  private Verification(String clue) {
+    this.clue = clue;
+  }
+
+  public boolean isOk() {
+    return this == OK;
+  }
+
+  public boolean isNotFound() {
+    return this == NOT_FOUND;
+  }
+
+  public String description(String verificationDesc) {
+    final String message;
+    if (isOk()) {
+      message = "Verified that " + verificationDesc;
+    } else if (isNotFound()) {
+      message = "Element not found. Failed to verify that " + verificationDesc;
+    } else {
+      message = "Failed to verify that " + verificationDesc;
+    }
+
+    if (clue == null) {
+      return message;
+    }
+    return message + ". " + clue;
+  }
 }

--- a/src/test/java/net/codestory/simplelenium/ShouldContainTextTest.java
+++ b/src/test/java/net/codestory/simplelenium/ShouldContainTextTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2013 all@code-story.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.codestory.simplelenium;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.simpleframework.http.Status.*;
+
+import java.io.*;
+import java.util.concurrent.TimeUnit;
+
+import net.codestory.simplelenium.misc.*;
+
+import org.junit.*;
+
+public class ShouldContainTextTest extends SeleniumTest {
+  private static final TimeUnit testFriendlyTime = TimeUnit.MILLISECONDS;
+
+  private WebServer webServer;
+
+  private void openPageWithContent(String body) throws IOException {
+    stopWebServerIfStarted();
+
+    webServer = new WebServer((req, resp) -> {
+      try {
+        resp.setStatus(OK);
+        resp.getPrintStream().print(body);
+        resp.close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }).startOnRandomPort();
+
+    goTo("/");
+  }
+
+  @After
+  public void stopWebServerIfStarted() throws IOException {
+    if (webServer != null) {
+      webServer.stop();
+    }
+  }
+
+  @Override
+  public String getDefaultBaseUrl() {
+    return "http://localhost:" + webServer.port();
+  }
+
+  @Test
+  public void element_does_not_exist_when_it_was_expected_to_contain_expected_text() throws Exception {
+    // given
+    openPageWithContent("<p>Some paragraph.</p>");
+
+    // when
+    try {
+      find("section").shouldWithin(1, testFriendlyTime).contain("blah");
+    }
+    // then
+    catch (AssertionError e) {
+      assertThat(e).hasMessage("Element not found. Failed to verify that section contains(blah)");
+    }
+  }
+
+  @Test
+  public void element_does_not_exist_when_it_was_expected_not_to_contain_unwanted_text() throws Exception {
+    // given
+    openPageWithContent("<p>Some long text.</p>");
+
+    // when
+    try {
+      find("section").shouldWithin(1, testFriendlyTime).not().contain("long");
+    }
+    // then
+    catch (AssertionError e) {
+      assertThat(e).hasMessage("Element not found. Failed to verify that section does not contain(long)");
+    }
+  }
+
+  @Test
+  public void element_exists_and_contains_expected_text() throws Exception {
+    // given
+    openPageWithContent("<p>Some short text.</p>");
+
+    // when
+    find("p").shouldWithin(1, testFriendlyTime).contain("short");
+
+    // then: no AssertionError is thrown
+  }
+
+  @Test
+  public void element_exists_but_does_not_contain_expected_text() throws Exception {
+    // given
+    openPageWithContent("<p>Some short text.</p>");
+
+    // when
+    try {
+      find("p").shouldWithin(1, testFriendlyTime).contain("long");
+    }
+    // then
+    catch (AssertionError e) {
+      assertThat(e).hasMessage("Failed to verify that p contains(long). p hasText(Some short text.)");
+    }
+  }
+
+  @Test
+  public void element_exists_and_does_not_contain_unwanted_text() throws Exception {
+    // given
+    openPageWithContent("<p>Some short text.</p>");
+
+    // when
+    find("p").shouldWithin(1, testFriendlyTime).not().contain("long");
+
+    // then: no AssertionError is thrown
+  }
+
+  @Test
+  public void element_exists_but_does_contain_unwanted_text() throws Exception {
+    // given
+    openPageWithContent("<p>Some long text.</p>");
+
+    // when
+    try {
+      find("p").shouldWithin(1, testFriendlyTime).not().contain("long");
+    }
+    // then
+    catch (AssertionError e) {
+      assertThat(e).hasMessage("Failed to verify that p does not contain(long). p hasText(Some long text.)");
+    }
+  }
+}


### PR DESCRIPTION
Hi David,

I find simplelenium to be exactly what we were trying to reach on a previous project, that is, a - well - simple wrapper that handles those silly timing issues. That said, at first we still had problems with our own "retry" solution: we had no clue about why exactly our test failed: was the target element missing, and if not what did it look like. So we improved our solution a bit to bring back the nice feedback of a simple "assertEqual": we attempted for each kind of check to give a maximum of details about the target element when it was actually found but did not pass the check.

I propose you an example of such a feature, implemented on your "contain" verification. If you're curious, I also had a try at implementing it in a lambda fashion, but that was a bit silly (see https://github.com/ndemengel/simplelenium/compare/feature;failure-clue-original-design?expand=1).

If that suits you, I can migrate the other verifications as well.
