### PR TITLE
Support multiple browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ set to go. **Simplelenium requires java 8**.
 <dependency>
   <groupId>net.code-story</groupId>
   <artifactId>simplelenium</artifactId>
-  <version>1.34</version>
+  <version>1.36</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/src/main/java/net/codestory/simplelenium/Context.java
+++ b/src/main/java/net/codestory/simplelenium/Context.java
@@ -15,29 +15,38 @@
  */
 package net.codestory.simplelenium;
 
-import net.codestory.simplelenium.driver.Browser;
-import net.codestory.simplelenium.driver.DriverInitializer;
-import net.codestory.simplelenium.driver.SeleniumDriver;
-import net.codestory.simplelenium.driver.ThreadSafeDriver;
+import net.codestory.simplelenium.configuration.Configuration;
+import net.codestory.simplelenium.driver.*;
 import org.openqa.selenium.remote.RemoteWebDriver;
-
-import java.util.function.Supplier;
 
 /**
  * Created by kag on 08/07/15.
  */
 public class Context {
 
-  private static ThreadLocal<SeleniumDriver> perThreadDriver = new ThreadLocal<SeleniumDriver>();
+  private static ThreadLocal<SeleniumDriver> perThreadDriver = new ThreadLocal<SeleniumDriver>() {
+    @Override
+    protected SeleniumDriver initialValue() {
+      Browser browser = currentBrowser.get();
+      DriverInitializerFactoryImpl driverInitializerFactory = DriverInitializerFactoryImpl.getInstance();
+      SeleniumDriver driver = driverInitializerFactory.getDriverInitializer(browser).createNewDriver();
+      return driver;
+    }
+  };
 
-  private static final ThreadLocal<Browser> currentBrowser = new ThreadLocal<>();
+  private static final ThreadLocal<Browser> currentBrowser = new ThreadLocal<Browser>() {
+    @Override
+    protected Browser initialValue() {
+      return Configuration.getInstance().getTargetBrowser();
+    }
+  };
 
   public static SeleniumDriver getCurrentWebDriver() {
     return perThreadDriver.get();
   }
 
-  public static void setCurrentWebDriver(RemoteWebDriver driver) {
-    perThreadDriver.set(ThreadSafeDriver.makeThreadSafe(driver));
+  public static void setCurrentWebDriver(SeleniumDriver driver) {
+    perThreadDriver.set(ThreadSafeDriver.makeThreadSafe((RemoteWebDriver) driver));
   }
 
   public static Browser getCurrentBrowser() {

--- a/src/main/java/net/codestory/simplelenium/DomElementFinder.java
+++ b/src/main/java/net/codestory/simplelenium/DomElementFinder.java
@@ -19,8 +19,6 @@ import net.codestory.simplelenium.filters.LazyDomElement;
 import org.openqa.selenium.By;
 
 public interface DomElementFinder {
-  // default syntax
-
   default DomElement find(String selector) {
     return new LazyDomElement(By.cssSelector(selector));
   }

--- a/src/main/java/net/codestory/simplelenium/SeleniumTest.java
+++ b/src/main/java/net/codestory/simplelenium/SeleniumTest.java
@@ -45,7 +45,7 @@ public abstract class SeleniumTest implements SectionObject {
     Context.setCurrentBrowser(browser);
 
     DriverInitializerFactoryImpl driverInitializerFactory = DriverInitializerFactoryImpl.getInstance();
-    RemoteWebDriver driver = driverInitializerFactory.getDriverInitializer(browser).createNewDriver();
+    SeleniumDriver driver = driverInitializerFactory.getDriverInitializer(browser).createNewDriver();
     Context.setCurrentWebDriver(driver);
   }
 

--- a/src/main/java/net/codestory/simplelenium/configuration/Configuration.java
+++ b/src/main/java/net/codestory/simplelenium/configuration/Configuration.java
@@ -81,8 +81,8 @@ public class Configuration {
    */
   public Browser getTargetBrowser() {
     if (this.targetBrowser == null) {
-      String browserProptery = System.getProperty("browser", "phantom_js");
-      this.targetBrowser = Browser.valueOf(browserProptery.trim().toUpperCase());
+      String browserProperty = System.getProperty("browser", "phantom_js");
+      this.targetBrowser = Browser.valueOf(browserProperty.trim().toUpperCase());
     }
     return this.targetBrowser;
   }

--- a/src/main/java/net/codestory/simplelenium/driver/DriverInitializer.java
+++ b/src/main/java/net/codestory/simplelenium/driver/DriverInitializer.java
@@ -30,5 +30,5 @@ public interface DriverInitializer {
   /**
    * @return the initialized driver
    */
-  public RemoteWebDriver createNewDriver();
+  public SeleniumDriver createNewDriver();
 }

--- a/src/main/java/net/codestory/simplelenium/driver/initializers/ChromeInitializer.java
+++ b/src/main/java/net/codestory/simplelenium/driver/initializers/ChromeInitializer.java
@@ -16,18 +16,12 @@
 package net.codestory.simplelenium.driver.initializers;
 
 import net.codestory.simplelenium.driver.*;
-import org.openqa.selenium.remote.RemoteWebDriver;
+import net.codestory.simplelenium.driver.ChromeDriver;
 
 /**
  * Created by kag on 07/07/15.
  */
 public class ChromeInitializer implements DriverInitializer {
-//    ThreadLocal<SeleniumDriver> perThreadDriver = new ThreadLocal<SeleniumDriver>() {
-//      @Override
-//      protected SeleniumDriver initialValue() {
-//        return createNewDriver();
-//      }
-//    };
 
   @Override
   public Browser getBrowser() {
@@ -35,7 +29,7 @@ public class ChromeInitializer implements DriverInitializer {
   }
 
   @Override
-  public RemoteWebDriver createNewDriver() {
+  public ChromeDriver createNewDriver() {
     return new ChromeDriver();
   }
 }

--- a/src/main/java/net/codestory/simplelenium/driver/initializers/PhantomJsInitializer.java
+++ b/src/main/java/net/codestory/simplelenium/driver/initializers/PhantomJsInitializer.java
@@ -15,10 +15,7 @@
  */
 package net.codestory.simplelenium.driver.initializers;
 
-import net.codestory.simplelenium.driver.Browser;
-import net.codestory.simplelenium.driver.DriverInitializer;
-import net.codestory.simplelenium.driver.LockFile;
-import net.codestory.simplelenium.driver.PhantomJSDriver;
+import net.codestory.simplelenium.driver.*;
 import org.openqa.selenium.net.PortProber;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 
@@ -56,7 +53,7 @@ public class PhantomJsInitializer implements DriverInitializer {
     return Browser.PHANTOM_JS;
   }
 
-  public PhantomJSDriver createNewDriver() {
+  public SeleniumDriver createNewDriver() {
     System.out.println("Create a new PhantomJSDriver");
 
     File phantomJsExe = null;


### PR DESCRIPTION
Basic support for Chrome driver. If no arguments are given, PhantomJS is used as a default. Otherwise you can specify the browser by passing "-Dbrowser=chrome". Apart from that the path to your driver executable must be given, e.g. "-Dwebdriver.chrome.driver=[PATH TO chromedriver.exe]".