### PR TITLE
Allow custom URL to access Phantomjs download

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,14 @@ tests can be run on Chrome or Firefox.
 Run tests with '-Dbrowser=chrome',  '-Dbrowser=firefox',  '-Dbrowser=phantom_js' to
 choose which browser you want to use.
 
+### Custom Download URL
+
+If you can't access default download url from where you are (thank you corporate IT proxy). You can override them by providing
+the following System properties :
+
+* `phantomjs.url` : url where to download phantomjs ie: https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-windows.zip 
+* `phantomjs.exe` : relative path where the executable is from the compressed archive. ie: phantomjs-1.9.8-windows/phantomjs.exe
+
 ## What Simplelenium doesn't do
 
 ### Support alerts, iframes and windows

--- a/src/main/java/net/codestory/simplelenium/driver/phantomjs/PhantomJsDownloader.java
+++ b/src/main/java/net/codestory/simplelenium/driver/phantomjs/PhantomJsDownloader.java
@@ -36,6 +36,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class PhantomJsDownloader {
   private static final int DEFAULT_RETRY_DOWNLOAD = 4;
   private static final int DEFAULT_RETRY_CONNECT = 4;
+  public static final String PHANTOMJS_URL = "PHANTOMJS_URL";
+  public static final String PHANTOMJS_EXE = "PHANTOMJS_EXE";
 
   private final int retryDownload;
   private final int retryConnect;
@@ -113,7 +115,11 @@ public class PhantomJsDownloader {
     try {
       String url;
       File phantomJsExe;
-      if (isWindows()) {
+      if (isCustomized()) {
+        System.out.println("Using custom url.");
+        url = System.getProperty(PHANTOMJS_URL);
+        phantomJsExe = new File(installDir, System.getProperty(PHANTOMJS_EXE));
+      } else if (isWindows()) {
         url = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-windows.zip";
         phantomJsExe = new File(installDir, "phantomjs-1.9.8-windows/phantomjs.exe");
       } else if (isMac()) {
@@ -133,6 +139,10 @@ public class PhantomJsDownloader {
     } finally {
       lock.release();
     }
+  }
+
+  protected boolean isCustomized() {
+    return System.getProperty(PHANTOMJS_URL) != null && System.getProperty(PHANTOMJS_EXE) != null;
   }
 
   protected void extractExe(String url, File phantomInstallDir, File phantomJsExe) {

--- a/src/main/java/net/codestory/simplelenium/driver/phantomjs/PhantomJsDownloader.java
+++ b/src/main/java/net/codestory/simplelenium/driver/phantomjs/PhantomJsDownloader.java
@@ -36,8 +36,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class PhantomJsDownloader {
   private static final int DEFAULT_RETRY_DOWNLOAD = 4;
   private static final int DEFAULT_RETRY_CONNECT = 4;
-  public static final String PHANTOMJS_URL = "PHANTOMJS_URL";
-  public static final String PHANTOMJS_EXE = "PHANTOMJS_EXE";
+  public static final String PHANTOMJS_URL = "phantomjs.url";
+  public static final String PHANTOMJS_EXE = "phantomjs.exe";
 
   private final int retryDownload;
   private final int retryConnect;
@@ -116,7 +116,6 @@ public class PhantomJsDownloader {
       String url;
       File phantomJsExe;
       if (isCustomized()) {
-        System.out.println("Using custom url.");
         url = System.getProperty(PHANTOMJS_URL);
         phantomJsExe = new File(installDir, System.getProperty(PHANTOMJS_EXE));
       } else if (isWindows()) {


### PR DESCRIPTION
I could say that this is useful whenever you want to try a new version of phantomjs whitout waiting for a new version to be bundled with simplelenium but the real reason is a reluctant corporate proxy.