### PR TITLE
Faster feedback from failing tests

### DIFF
--- a/src/main/java/net/codestory/simplelenium/filters/LazyDomElement.java
+++ b/src/main/java/net/codestory/simplelenium/filters/LazyDomElement.java
@@ -40,7 +40,7 @@ public class LazyDomElement implements DomElement {
   private final Retry retry;
 
   public LazyDomElement(By selector) {
-    this(selector, Retry._30_SECONDS);
+    this(selector, Retry.DEFAULT_TIMEOUT);
   }
 
   public LazyDomElement(By selector, Retry retry) {
@@ -48,7 +48,7 @@ public class LazyDomElement implements DomElement {
   }
 
   public LazyDomElement(LazyDomElement parent, By selector) {
-    this(parent, selector, Retry._30_SECONDS);
+    this(parent, selector, Retry.DEFAULT_TIMEOUT);
   }
 
   public LazyDomElement(LazyDomElement parent, By selector, Retry retry) {
@@ -171,7 +171,7 @@ public class LazyDomElement implements DomElement {
 
   @Override
   public Should should() {
-    return new LazyShould(this, Retry._30_SECONDS, true);
+    return new LazyShould(this, Retry.DEFAULT_TIMEOUT, true);
   }
 
   // Actions

--- a/src/main/java/net/codestory/simplelenium/filters/Retry.java
+++ b/src/main/java/net/codestory/simplelenium/filters/Retry.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 class Retry {
-  public static final Retry DEFAULT_TIMEOUT = new Retry(30, SECONDS);
+  public static final Retry DEFAULT_TIMEOUT = new Retry(5, SECONDS);
 
   private final long timeoutInMs;
 

--- a/src/main/java/net/codestory/simplelenium/filters/Retry.java
+++ b/src/main/java/net/codestory/simplelenium/filters/Retry.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 class Retry {
-  public static final Retry _30_SECONDS = new Retry(30, SECONDS);
+  public static final Retry DEFAULT_TIMEOUT = new Retry(30, SECONDS);
 
   private final long timeoutInMs;
 


### PR DESCRIPTION
I'm really glad to see someone tackle the issues we face with selenium tests, thanks for all your hard work so far!

I'd like to suggest lowering the default timeout from 30 seconds down to 5 seconds. 

I (and others I've paired with) have found the timeout frustrating if there are issues tweaking the app we're testing. 5 seconds is also a more reasonable feedback loop when test driving.

I'm also going to open up another issue for configuring the default timeout that I plan to make a pull request against.
