### PR TITLE
Update ChromeDriverDownloader.java

### DIFF
--- a/src/main/java/net/codestory/simplelenium/driver/chrome/ChromeDriverDownloader.java
+++ b/src/main/java/net/codestory/simplelenium/driver/chrome/ChromeDriverDownloader.java
@@ -120,16 +120,16 @@ public class ChromeDriverDownloader extends Downloader {
         url = Configuration.CHROMEDRIVER_URL.get();
         chromeDriverExe = new File(installDir, Configuration.CHROMEDRIVER_EXE.get());
       } else if (isWindows()) {
-        url = "https://chromedriver.storage.googleapis.com/2.19/chromedriver_win32.zip";
+        url = "https://chromedriver.storage.googleapis.com/2.9/chromedriver_win32.zip";
         chromeDriverExe = new File(installDir, "chromedriver.exe");
       } else if (isMac()) {
-        url = "https://chromedriver.storage.googleapis.com/2.19/chromedriver_mac32.zip";
+        url = "https://chromedriver.storage.googleapis.com/2.9/chromedriver_mac32.zip";
         chromeDriverExe = new File(installDir, "chromedriver");
       } else if (isLinux32()) {
-        url = "https://chromedriver.storage.googleapis.com/2.19/chromedriver_linux32.zip";
+        url = "https://chromedriver.storage.googleapis.com/2.9/chromedriver_linux32.zip";
         chromeDriverExe = new File(installDir, "chromedriver");
       } else {
-        url = "https://chromedriver.storage.googleapis.com/2.19/chromedriver_linux64.zip";
+        url = "https://chromedriver.storage.googleapis.com/2.9/chromedriver_linux64.zip";
         chromeDriverExe = new File(installDir, "chromedriver");
       }
 


### PR DESCRIPTION
Chrome v54 seems to be having issues with Chromedriver v2.19, so updating this file to include chromedriver v2.9. 

When running tests, the browser opens and closes, and the logs show this error:

org.openqa.selenium.SessionNotCreatedException: session not created exception
from unknown error: Runtime.executionContextCreated has invalid 'context': {"auxData":{"frameId":"65792.1","isDefault":true},"id":1,"name":"","origin":"://"}
  (Session info: chrome=54.0.2840.71)
  (Driver info: chromedriver=2.19.346063 (38b35413bd4a486d436a9749e090454bc9ff6708),platform=Mac OS X 10.10.5 x86_64) (WARNING: The server did not provide any stacktrace information)
Command duration or timeout: 999 milliseconds